### PR TITLE
website: Mention that these numbers are ONLY for 32-bit x86

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" >
 
-    <title>Linux Syscall Reference</title>
+    <title>Linux Syscall Reference for 32-bit x86 (other arches differ)</title>
     <style type="text/css" title="currentStyle">
       @import "css/page.css";
       @import "css/table_jui.css";


### PR DESCRIPTION
See https://fedora.juszkiewicz.com.pl/syscalls.html for the fact that other arches
have completely different syscall numbers, including x86_64, where e.g.
read() is 0, not 3.

This confusion actually resulted in one of my prototype programs being wrong :)